### PR TITLE
feature: str_contains fn

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -19,6 +19,7 @@ static struct object builtin_array_pop(struct object_list* args);
 static struct object builtin_array_push(struct object_list* args);
 static struct object builtin_file_get_contents(const struct object_list* args);
 static struct object str_split(const struct object_list* args);
+static struct object str_contains(const struct object_list* args);
 
 
 // here we store the built-in function directly on the pointer by casting it to the wrong value
@@ -35,6 +36,7 @@ const struct {
     { "array_push", MAKE_BUILTIN(builtin_array_push) },
     { "file_get_contents", MAKE_BUILTIN(builtin_file_get_contents) },
     { "str_split", MAKE_BUILTIN(str_split) },
+    { "str_contains", MAKE_BUILTIN(str_contains) }
 };
 
 inline 
@@ -225,4 +227,23 @@ str_split(const struct object_list *args) {
     strcpy(buf, str);
     list = append_to_object_list(list, make_string_object(buf));
     return make_array_object(list);
+}
+
+static struct object 
+str_contains(const struct object_list *args) {
+    if (args->size != 2) {
+        return make_error_object("wrong number of arguments: expected 2, got %d", args->size);
+    }
+
+    if (args->values[0].type != OBJ_STRING || args->values[1].type != OBJ_STRING) {
+        return make_error_object("invalid argument: expected %s, got %s", object_type_to_str(OBJ_STRING), object_type_to_str(args->values[0].type));
+    }
+
+    const char* subject = (char*) args->values[0].value.ptr->value;
+    const char* search = (char*) args->values[1].value.ptr->value;
+    char* ret;
+
+    ret = strstr(subject, search);
+
+    return make_boolean_object(ret != NULL);
 }

--- a/src/object.c
+++ b/src/object.c
@@ -34,6 +34,14 @@ struct object make_integer_object(const int64_t value)
     };
 }
 
+struct object make_boolean_object(const bool value)
+{
+    return (struct object) {
+        .type = OBJ_BOOL,
+        .value.boolean = value
+    };
+}
+
 struct object make_array_object(struct object_list *elements) 
 {
     struct object obj;

--- a/src/object.h
+++ b/src/object.h
@@ -68,6 +68,7 @@ struct object_list {
 
 const char *object_type_to_str(const enum object_type t);
 struct object make_integer_object(const int64_t value);
+struct object make_boolean_object(const bool value);
 struct object make_string_object(const char *str1);
 struct object make_string_object_with_length(const char *str, size_t length);
 struct object make_error_object(const char *format, ...);

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,5 +1,4 @@
 #include <assert.h>
-#include <bits/stdint-intn.h>
 #include <ctype.h>
 #include <stdint.h>
 #include <stdlib.h>


### PR DESCRIPTION
This pull request introduces a new `str_contains` function:

```
str_contains("example", "exam); // returns `true`
str_contains("dog", "cat"); // returns `false`
```

If you're not interested, don't worry. I just wanted to have a play around with the core and see how everything works.

**Note**: I had to remove the `#include <bits/stdint-intn.h>` header since it prevented me from compiling on macOS... 